### PR TITLE
Drop unneeded build requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yaml and/or the recipe/meta.yaml.
 
-language: objective-c
+language: generic
+
+os: osx
 
 env:
   matrix:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Terminology
 Current build status
 ====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/pies-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/pies-feedstock)
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/pies-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/pies-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/pies-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/pies-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/pies-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/pies-feedstock/branch/master)
 
@@ -83,12 +83,17 @@ Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pies/badge
 Updating pies-feedstock
 =======================
 
-If you would like to improve the pies recipe, please take the normal
-route of forking this repository and submitting a PR. Upon submission, your changes will
-be run on the appropriate platforms to give the reviewer an opportunity to confirm that the
-changes result in a successful build. Once merged, the recipe will be re-built and uploaded
-automatically to the conda-forge channel, whereupon they will be available for everybody to
-install and use.
+If you would like to improve the pies recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/pies-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 4 case(s).
+# Embarking on 3 case(s).
     set -x
     export CONDA_PY=27
     set +x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,6 @@ requirements:
   build:
     - python
     - setuptools
-    - pies2overrides  # [py2k]
-    - enum34          # [py<34]
-    - argparse        # [py3k and py<33]
-    - ordereddict     # [py3k and py<33]
   run:
     - python
     - pies2overrides  # [py2k]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/pies-feedstock/issues/1
Closes https://github.com/conda-forge/pies-feedstock/pull/3
Closes https://github.com/conda-forge/pies-feedstock/pull/4

Drops unneeded build requirements from the list. As these dependencies only needed to be satisfied at install time, we drop them from the build requirements list. This seems to also have the consequence that the re-rendering goes through smoothly with out dropping Python 3.4 and 3.5 builds. Not sure why this should matter, but maybe this will help narrow things down.

cc @pelson
